### PR TITLE
Use fixed order for VM Options

### DIFF
--- a/memory/vmoptions.go
+++ b/memory/vmoptions.go
@@ -99,7 +99,11 @@ func (vm *vmOptions) DeltaString() string {
 	var bb bytes.Buffer
 
 	first := true
-	for k, v := range vm.memOpts {
+	for k := MemoryType(0); k < MemoryTypeLimit; k++ {
+		v, ok := vm.memOpts[k]
+		if !ok {
+			continue
+		}
 		if vm.memOptWasRaw[k] {
 			continue
 		}


### PR DESCRIPTION
Hi! We' using this tool in a system that track changes to config files. For this, it would be highly useful if the order of output options does not vary between runs, if the input parameters are the same.

This PR just copies the loop defined in the String function below to the DeltaString function, so that the output order is well-defined.