### PR TITLE
Fix installation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ In order to perform this calculation, the Memory Calculator requires the followi
 The Memory Calculator prints the calculated JVM configuration flags (_excluding_ any that the user has specified in `--jvm-options`).  If a valid configuration cannot be calculated (e.g. more memory must be allocated than is available), an error is printed and a non-zero exit code is returned.  In order to **override** a calculated value, users should pass any of the standard JVM configuration flags into `--jvm-options`.  The calculation will take these as fixed values and adjust the non-fixed values accordingly.
 
 ## Install  
-go get -v github.com/cloudfoundry/java-buildpack-memory-calculator/v4  
+
+```sh
+$ go get -v github.com/cloudfoundry/java-buildpack-memory-calculator
+```
 
 ## Algorithm
 


### PR DESCRIPTION
The current installation command from project's readme yields the following error:

```sh
$ go get -v github.com/cloudfoundry/java-buildpack-memory-calculator/v4
github.com/cloudfoundry/java-buildpack-memory-calculator (download)
package github.com/cloudfoundry/java-buildpack-memory-calculator/v4: cannot find package "github.com/cloudfoundry/java-buildpack-memory-calculator/v4" in any of:
	/usr/lib/go-1.14/src/github.com/cloudfoundry/java-buildpack-memory-calculator/v4 (from $GOROOT)
	/home/vpavic/go/src/github.com/cloudfoundry/java-buildpack-memory-calculator/v4 (from $GOPATH)
```

Whereas the command from this proposed update results in a clean installation:

```sh
$ go get -v github.com/cloudfoundry/java-buildpack-memory-calculator
github.com/spf13/pflag (download)
github.com/cloudfoundry/java-buildpack-memory-calculator/memory
github.com/spf13/pflag
github.com/cloudfoundry/java-buildpack-memory-calculator/flags
github.com/cloudfoundry/java-buildpack-memory-calculator/calculator
github.com/cloudfoundry/java-buildpack-memory-calculator
```

It seems that the current command is a result of project-wide search & replace that was done in 709ddef.