### PR TITLE
Update installation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Memory Calculator prints the calculated JVM configuration flags (_excluding_
 ## Install  
 
 ```sh
-$ go get -v github.com/cloudfoundry/java-buildpack-memory-calculator
+$ go install github.com/cloudfoundry/java-buildpack-memory-calculator@latest
 ```
 
 ## Algorithm


### PR DESCRIPTION
While attempting to install memory calculator with the recent version of Go (specifically `1.20.2`) I was greeted with the following:

```sh
$ go get -v github.com/cloudfoundry/java-buildpack-memory-calculator
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

This PR updates the install command according to the guidance from the link in the error message from above:

```sh
$ go install github.com/cloudfoundry/java-buildpack-memory-calculator@latest
go: downloading github.com/cloudfoundry/java-buildpack-memory-calculator v0.0.0-20190501234420-5148668b0710
go: downloading github.com/spf13/pflag v1.0.3
```